### PR TITLE
Reintroduce matrix splitting 

### DIFF
--- a/src/SplitMatrixRenderer.ts
+++ b/src/SplitMatrixRenderer.ts
@@ -1,4 +1,4 @@
-import { ICellRendererFactory, NumbersColumn, Column, isNumbersColumn, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers, NestedColumn, createNestedDesc, IGroupCellRenderer, ICellRenderer } from 'lineupjs';
+import { ICellRendererFactory, NumbersColumn, Column, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers, NestedColumn, createNestedDesc, IGroupCellRenderer, ICellRenderer } from 'lineupjs';
 
 
 /**

--- a/src/SplitMatrixRenderer.ts
+++ b/src/SplitMatrixRenderer.ts
@@ -1,118 +1,107 @@
-import { ICellRendererFactory, NumbersColumn, Column, isNumbersColumn, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers } from 'lineupjs';
+import { ICellRendererFactory, NumbersColumn, Column, isNumbersColumn, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers, NestedColumn, createNestedDesc, IGroupCellRenderer, ICellRenderer } from 'lineupjs';
 
-
-/** @internal */
-export function noop() {
-  // no op
-}
-
-/** @internal */
-export const noRenderer = {
-  template: `<div></div>`,
-  update: noop,
-  render: noop
-};
-
-export interface IStratification {
-  name: string;
-  categories: (ICategory | string)[];
-  data: string[];
-}
-
-export class SplitMatrixRenderer implements ICellRendererFactory {
-  readonly title = 'SplitMatrix';
-
-  constructor(private categories: IStratification[]) {
-    console.log(categories);
-
-  }
-
-  canRender(col: Column) {
-    return isNumbersColumn(col);
-  }
-
-  create(col: NumbersColumn) {
-    return noRenderer;
-  }
-
-  createGroup() {
-    return noRenderer;
-  }
-
-  createSummary(col: NumbersColumn, context: IRenderContext, interactive: boolean, imposer?: any) {
-    if (!interactive) {
-      return renderers.histogram.createSummary(col, context, interactive, imposer);
-    }
-
-    return {
-      template: `<div></div>`,
-      update: (node: HTMLElement, hist: IStatistics | ICategoricalStatistics | null): void => {
-        node.dataset.summary = 'stratify';
-        node.innerHTML = `<select>
-            <option value="">Stratify by...</option>
-            ${this.categories.map((d) => `<option value="${d.name}">${d.name}</option>`).join('')}
-        </select>`;
-        const select = <HTMLSelectElement>node.firstElementChild!;
-      }
-    };
-  }
-}
 
 /**
  * special summary to split a matrix by a categorical attribute
  * @param {IStratification[]} categories
  * @return {ISummaryFunction}
  */
-/*
-export function matrixSplicer(categories: IStratification[]) {
-  return (col: NumbersColumn, node: HTMLElement, interactive: boolean, ctx) => {
-    node.dataset.summary = 'stratify';
-    const allLabels = (<any>col.desc).labels || [];
-    if (!interactive) {
-      // our custom splice also provides labels
-      const labels = (<any>col.getSplicer()).labels || allLabels;
-      if (!labels) {
-        node.innerHTML = '';
-      }
-      node.innerHTML = `<span>${labels[0]}</span><span>${labels[labels.length - 1]}</span>`;
-      return;
-    }
-    node.innerHTML = `<select>
-        <option value="">Stratify by...</option>
-        ${categories.map((d) => `<option value="${d.name}">${d.name}</option>`).join('')}
-    </select>`;
-    const select = <HTMLSelectElement>node.firstElementChild!;
-    select.addEventListener('change', (evt) => {
-      evt.preventDefault();
-      evt.stopPropagation();
-
-      const selected = categories[select.selectedIndex - 1]; // empty option
-      if (!selected) {
-        return;
-      }
-      const base = <NestedColumn>ctx.provider.create(createNestedDesc(`${col.getMetaData().label} by ${selected.name}`));
-      const w = col.getWidth();
-      selected.categories.forEach((group) => {
-        const g = typeof group === 'string' ? {name: group, label: group} : group;
-        const gcol = <NumbersColumn>ctx.provider.clone(col);
-        // set group name
-        gcol.setMetaData({label: g.label || g.name, color: g.color || Column.DEFAULT_COLOR, description: ''});
-
-        const length = selected.data.reduce((a, s) => a + (s === g.name ? 1 : 0), 0);
-        gcol.setSplicer(<any>{
-          length,
-          splice: (vs) => vs.filter((_v, i) => selected.data[i] === g.name),
-          labels: allLabels.filter((_v, i) => selected.data[i] === g.name)
-        });
-        gcol.setWidth(w * length / selected.data.length);
-
-        base.push(gcol);
-      });
-
-      // replace with splitted value
-      col.insertAfterMe(base);
-      col.removeMe();
-    });
-  };
+export interface IStratification {
+  name: string;
+  categories: (ICategory | string)[];
+  data: string[];
 }
-*/
+
+/**
+ * Extends the histogram renderer by adding a select field to the summary renderer.
+ * The renderer needs a list of stratifications in the constructor
+ */
+export class SplitMatrixRenderer implements ICellRendererFactory {
+  readonly title = 'Histogram + Matrix Splitter';
+  private readonly histogramRenderer = renderers.histogram;
+
+  constructor(private categories: IStratification[]) {
+    //
+  }
+
+  canRender(col: Column, mode: any /*ERenderMode*/): boolean {
+    return this.histogramRenderer.canRender(col, mode);
+  }
+
+  create(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: any/*IImposer*/): ICellRenderer {
+    return this.histogramRenderer.create(col, context, hist, imposer);
+  }
+
+  createGroup(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: any/*IImposer*/): IGroupCellRenderer {
+    return this.histogramRenderer.createGroup(col, context, hist, imposer);
+  }
+
+  createSummary(col: NumbersColumn, context: IRenderContext, interactive: boolean, imposer?: any/*IImposer*/) {
+    const histogramRenderer = this.histogramRenderer.createSummary(col, context, interactive, imposer);
+    if (!interactive) {
+      return {
+        template: histogramRenderer.template,
+        update: (node: HTMLElement, hist: IStatistics | ICategoricalStatistics | null): void => {
+          // use original histogram summary and add the select field
+          histogramRenderer.update(node, hist);
+          node.dataset.renderer = 'histogram';
+        }
+      };
+    }
+
+    const allLabels = (<any>col.desc).labels || [];
+
+    return {
+      template: histogramRenderer.template,
+      update: (node: HTMLElement, hist: IStatistics | ICategoricalStatistics | null): void => {
+        // use original histogram summary and add the select field
+        histogramRenderer.update(node, hist);
+        node.dataset.renderer = 'histogram';
+
+        if (node.querySelector('select') || this.categories.length === 0) {
+          return; // prevent adding two select fields
+        }
+
+        node.dataset.summary = 'stratify';
+
+        node.innerHTML += `<select>
+            <option value="">Split matrix by...</option>
+            ${this.categories.map((d) => `<option value="${d.name}">${d.name}</option>`).join('')}
+        </select>`;
+
+        const select = <HTMLSelectElement>node.querySelector('select')!;
+        select.addEventListener('change', (evt) => {
+          evt.preventDefault();
+          evt.stopPropagation();
+
+          const selected = this.categories[select.selectedIndex - 1]; // empty option
+          if (!selected) {
+            return;
+          }
+          const base = <NestedColumn>context.provider.create(createNestedDesc(`${col.getMetaData().label} by ${selected.name}`));
+          const w = col.getWidth();
+          selected.categories.forEach((group) => {
+            const g = typeof group === 'string' ? { name: group, label: group, color: undefined } : group;
+            const gcol = <NumbersColumn>context.provider.clone(col);
+            // set group name
+            gcol.setMetaData({ label: g.label || g.name, color: g.color || Column.DEFAULT_COLOR, description: '' });
+
+            const length = selected.data.reduce((a, s) => a + (s === g.name ? 1 : 0), 0);
+            gcol.setSplicer(<any>{
+              length,
+              splice: (vs: any[]) => vs.filter((_v: any, i: number) => selected.data[i] === g.name),
+              labels: allLabels.filter((_v: any, i: number) => selected.data[i] === g.name)
+            });
+            gcol.setWidth(w * length / selected.data.length);
+
+            base.push(gcol);
+          });
+
+          // replace with splitted value
+          col.insertAfterMe(base);
+          col.removeMe();
+        });
+      }
+    };
+  }
+}

--- a/src/SplitMatrixRenderer.ts
+++ b/src/SplitMatrixRenderer.ts
@@ -1,4 +1,4 @@
-import { ICellRendererFactory, NumbersColumn, Column, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers, NestedColumn, createNestedDesc, IGroupCellRenderer, ICellRenderer } from 'lineupjs';
+import { ICellRendererFactory, NumbersColumn, Column, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers, NestedColumn, createNestedDesc, IGroupCellRenderer, ICellRenderer, IImposer } from 'lineupjs';
 
 
 /**
@@ -28,15 +28,15 @@ export class SplitMatrixRenderer implements ICellRendererFactory {
     return this.histogramRenderer.canRender(col, mode);
   }
 
-  create(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: any/*IImposer*/): ICellRenderer {
+  create(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: IImposer): ICellRenderer {
     return this.histogramRenderer.create(col, context, hist, imposer);
   }
 
-  createGroup(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: any/*IImposer*/): IGroupCellRenderer {
+  createGroup(col: Column, context: IRenderContext, hist: IStatistics | ICategoricalStatistics | null, imposer?: IImposer): IGroupCellRenderer {
     return this.histogramRenderer.createGroup(col, context, hist, imposer);
   }
 
-  createSummary(col: NumbersColumn, context: IRenderContext, interactive: boolean, imposer?: any/*IImposer*/) {
+  createSummary(col: NumbersColumn, context: IRenderContext, interactive: boolean, imposer?: IImposer) {
     const histogramRenderer = this.histogramRenderer.createSummary(col, context, interactive, imposer);
     if (!interactive) {
       return {

--- a/src/SplitMatrixRenderer.ts
+++ b/src/SplitMatrixRenderer.ts
@@ -1,0 +1,118 @@
+import { ICellRendererFactory, NumbersColumn, Column, isNumbersColumn, IStatistics, ICategoricalStatistics, ICategory, IRenderContext, renderers } from 'lineupjs';
+
+
+/** @internal */
+export function noop() {
+  // no op
+}
+
+/** @internal */
+export const noRenderer = {
+  template: `<div></div>`,
+  update: noop,
+  render: noop
+};
+
+export interface IStratification {
+  name: string;
+  categories: (ICategory | string)[];
+  data: string[];
+}
+
+export class SplitMatrixRenderer implements ICellRendererFactory {
+  readonly title = 'SplitMatrix';
+
+  constructor(private categories: IStratification[]) {
+    console.log(categories);
+
+  }
+
+  canRender(col: Column) {
+    return isNumbersColumn(col);
+  }
+
+  create(col: NumbersColumn) {
+    return noRenderer;
+  }
+
+  createGroup() {
+    return noRenderer;
+  }
+
+  createSummary(col: NumbersColumn, context: IRenderContext, interactive: boolean, imposer?: any) {
+    if (!interactive) {
+      return renderers.histogram.createSummary(col, context, interactive, imposer);
+    }
+
+    return {
+      template: `<div></div>`,
+      update: (node: HTMLElement, hist: IStatistics | ICategoricalStatistics | null): void => {
+        node.dataset.summary = 'stratify';
+        node.innerHTML = `<select>
+            <option value="">Stratify by...</option>
+            ${this.categories.map((d) => `<option value="${d.name}">${d.name}</option>`).join('')}
+        </select>`;
+        const select = <HTMLSelectElement>node.firstElementChild!;
+      }
+    };
+  }
+}
+
+/**
+ * special summary to split a matrix by a categorical attribute
+ * @param {IStratification[]} categories
+ * @return {ISummaryFunction}
+ */
+/*
+export function matrixSplicer(categories: IStratification[]) {
+  return (col: NumbersColumn, node: HTMLElement, interactive: boolean, ctx) => {
+    node.dataset.summary = 'stratify';
+    const allLabels = (<any>col.desc).labels || [];
+    if (!interactive) {
+      // our custom splice also provides labels
+      const labels = (<any>col.getSplicer()).labels || allLabels;
+      if (!labels) {
+        node.innerHTML = '';
+      }
+      node.innerHTML = `<span>${labels[0]}</span><span>${labels[labels.length - 1]}</span>`;
+      return;
+    }
+    node.innerHTML = `<select>
+        <option value="">Stratify by...</option>
+        ${categories.map((d) => `<option value="${d.name}">${d.name}</option>`).join('')}
+    </select>`;
+    const select = <HTMLSelectElement>node.firstElementChild!;
+    select.addEventListener('change', (evt) => {
+      evt.preventDefault();
+      evt.stopPropagation();
+
+      const selected = categories[select.selectedIndex - 1]; // empty option
+      if (!selected) {
+        return;
+      }
+      const base = <NestedColumn>ctx.provider.create(createNestedDesc(`${col.getMetaData().label} by ${selected.name}`));
+      const w = col.getWidth();
+      selected.categories.forEach((group) => {
+        const g = typeof group === 'string' ? {name: group, label: group} : group;
+        const gcol = <NumbersColumn>ctx.provider.clone(col);
+        // set group name
+        gcol.setMetaData({label: g.label || g.name, color: g.color || Column.DEFAULT_COLOR, description: ''});
+
+        const length = selected.data.reduce((a, s) => a + (s === g.name ? 1 : 0), 0);
+        gcol.setSplicer(<any>{
+          length,
+          splice: (vs) => vs.filter((_v, i) => selected.data[i] === g.name),
+          labels: allLabels.filter((_v, i) => selected.data[i] === g.name)
+        });
+        gcol.setWidth(w * length / selected.data.length);
+
+        base.push(gcol);
+      });
+
+      // replace with splitted value
+      col.insertAfterMe(base);
+      col.removeMe();
+    });
+  };
+}
+*/

--- a/src/data/soccer/index.ts
+++ b/src/data/soccer/index.ts
@@ -1,6 +1,6 @@
 import { IDataset } from '../IDataset';
 import { parse, ParseResult } from 'papaparse';
-import { builder, buildRanking, buildStringColumn, buildCategoricalColumn, buildNumberColumn, renderers } from 'lineupjs';
+import { builder, buildRanking, buildStringColumn, buildCategoricalColumn, buildNumberColumn } from 'lineupjs';
 import '!file-loader?name=preview.png!./soccer.png';
 import { SplitMatrixRenderer, IStratification } from '../../SplitMatrixRenderer';
 

--- a/src/data/soccer/index.ts
+++ b/src/data/soccer/index.ts
@@ -20,7 +20,6 @@ function stratifications(): IStratification[] {
         ]
       }
     }
-
   ];
 
   return descs.map((d) => {
@@ -66,10 +65,10 @@ export const data: IDataset = {
     .column(buildNumberColumn('height', [0, NaN]))
     .column(buildStringColumn('nationality'))
     .column(buildCategoricalColumn('position'))
-    .column(buildNumberColumn('games', [0, NaN]).asArray(4))
-    .column(buildNumberColumn('goals', [0, NaN]).asArray(4))
-    .column(buildNumberColumn('minutes', [0, NaN]).asArray(4))
-    .column(buildNumberColumn('assists', [0, NaN]).asArray(4))
+    .column(buildNumberColumn('games', [0, NaN]).asArray(6))
+    .column(buildNumberColumn('goals', [0, NaN]).asArray(6))
+    .column(buildNumberColumn('minutes', [0, NaN]).asArray(6)))
+    .column(buildNumberColumn('assists', [0, NaN]).asArray(6))
     .deriveColors()
     .ranking(buildRanking()
       .supportTypes()
@@ -106,10 +105,10 @@ export const data: IDataset = {
         .column(buildNumberColumn('height', [0, NaN]))
         .column(buildStringColumn('nationality'))
         .column(buildCategoricalColumn('position'))
-        .column(buildNumberColumn('games', [0, NaN]).asArray(4).width(300))
-        .column(buildNumberColumn('goals', [0, NaN]).asArray(4).width(300).renderer(undefined, undefined, 'splitmatrix'))
-        .column(buildNumberColumn('minutes', [0, NaN]).asArray(4))
-        .column(buildNumberColumn('assists', [0, NaN]).asArray(4))
+        .column(buildNumberColumn('games', [0, NaN]).asArray(6).width(300).renderer(undefined, undefined, 'splitmatrix'))
+        .column(buildNumberColumn('goals', [0, NaN]).asArray(6).width(300).renderer(undefined, undefined, 'splitmatrix'))
+        .column(buildNumberColumn('minutes', [0, NaN]).asArray(6).renderer(undefined, undefined, 'splitmatrix'))
+        .column(buildNumberColumn('assists', [0, NaN]).asArray(6).renderer(undefined, undefined, 'splitmatrix'))
         .deriveColors()
         .ranking(buildRanking()
           .supportTypes()

--- a/src/data/soccer/index.ts
+++ b/src/data/soccer/index.ts
@@ -1,7 +1,36 @@
 import { IDataset } from '../IDataset';
 import { parse, ParseResult } from 'papaparse';
-import { builder, buildRanking, buildStringColumn, buildCategoricalColumn, buildNumberColumn } from 'lineupjs';
+import { builder, buildRanking, buildStringColumn, buildCategoricalColumn, buildNumberColumn, renderers } from 'lineupjs';
 import '!file-loader?name=preview.png!./soccer.png';
+import { SplitMatrixRenderer, IStratification } from '../../SplitMatrixRenderer';
+
+
+function stratifications(): IStratification[] {
+  const descs = [
+    {
+      name: 'season',
+      value: {
+        categories: [
+          '12/13',
+          '13/14',
+          '14/15',
+          '15/16',
+          '16/17',
+          '17/18',
+        ]
+      }
+    }
+
+  ];
+
+  return descs.map((d) => {
+    return {
+      name: d.name,
+      categories: d.value.categories,
+      data: d.value.categories
+    };
+  });
+}
 
 export const data: IDataset = {
   id: 'soccer',
@@ -66,7 +95,9 @@ export const data: IDataset = {
           row[col] = suffix.map((d) => !row[`${col}${d}`] && row[`${col}${d}`] !== 0 ? null : row[`${col}${d}`]);
         });
       });
+
       return builder(parsed.data)
+        .registerRenderer('splitmatrix', new SplitMatrixRenderer(stratifications()))
         .column(buildStringColumn('player').width(150))
         .column(buildNumberColumn('age', [0, NaN]))
         .column(buildStringColumn('current_club').width(100).label('Current Club'))
@@ -76,7 +107,7 @@ export const data: IDataset = {
         .column(buildStringColumn('nationality'))
         .column(buildCategoricalColumn('position'))
         .column(buildNumberColumn('games', [0, NaN]).asArray(4).width(300))
-        .column(buildNumberColumn('goals', [0, NaN]).asArray(4).width(300))
+        .column(buildNumberColumn('goals', [0, NaN]).asArray(4).width(300).renderer(undefined, undefined, 'splitmatrix'))
         .column(buildNumberColumn('minutes', [0, NaN]).asArray(4))
         .column(buildNumberColumn('assists', [0, NaN]).asArray(4))
         .deriveColors()

--- a/src/style.scss
+++ b/src/style.scss
@@ -174,6 +174,16 @@ label {
   line-height: 100%;
 }
 
+article.lu-side-panel-entry .lu-summary[data-renderer="histogram"][data-summary="stratify"] {
+  margin-bottom: 8em;
+
+  select {
+    display: block;
+    position: absolute;
+    bottom: -7em;
+  }
+}
+
 .lu-side-panel {
   padding-top: 2em;
 


### PR DESCRIPTION
closes #8

### Summary
 
![lineup-matrix-splitting](https://user-images.githubusercontent.com/5851088/42092099-fec7825e-7ba7-11e8-80dd-ad4df70110f4.gif)

### Open issues

* After splitting only the first column `12/13` is added to the side panel. All others are ignored. I don't know why. (related to https://github.com/Caleydo/lineupjs/issues/533 and https://github.com/Caleydo/lineupjs/issues/531)

Maybe @sgratzl can have a look at this and/or comment.