### PR TITLE
New color scheme for AIDS dataset

### DIFF
--- a/src/data/aids/AIDS_Countries.json
+++ b/src/data/aids/AIDS_Countries.json
@@ -113,27 +113,27 @@
     {
       "column": "continent",
       "categories": [{
-          "color": "#b2df8a",
+          "color": "#66c2a5",
           "name": "Africa"
         },
         {
-          "color": "#a6cee3",
+          "color": "#ffd92f",
           "name": "Asia"
         },
         {
-          "color": "#1f78b4",
+          "color": "#a6d854",
           "name": "Europe"
         },
         {
-          "color": "#e31a1c",
+          "color": "#e78ac3",
           "name": "North America"
         },
         {
-          "color": "#fb9a99",
+          "color": "#8da0cb",
           "name": "Oceania"
         },
         {
-          "color": "#33a02c",
+          "color": "#fc8d62",
           "name": "South America"
         }
       ],

--- a/src/data/aids/AIDS_Countries.json
+++ b/src/data/aids/AIDS_Countries.json
@@ -92,19 +92,19 @@
     {
       "column": "human_development_index",
       "categories": [{
-          "color": "#ca0020",
+          "color": "#ffffcc",
           "name": "1 Low human development"
         },
         {
-          "color": "#f4a582",
+          "color": "#a1dab4",
           "name": "2 Medium human development"
         },
         {
-          "color": "#92c5de",
+          "color": "#41b6c4",
           "name": "3 High human development"
         },
         {
-          "color": "#0571b0",
+          "color": "#225ea8",
           "name": "4 Very high human development"
         }
       ],


### PR DESCRIPTION
Inital request from @katush:
> I think for Discriminatory attitude we can use the one that was used originally - I believe it was this one - ['#feebe2 ','#fbb4b9 ','#f768a1 ','#c51b8a ','#7a0177 ']
>
> For Humen Devel. Index I would go for another sequential scheme, e.g., this - ['#ffffcc ','#a1dab4 ','#41b6c4 ','#225ea8 ']
>
> For Continent ['#66c2a5 ','#fc8d62 ','#8da0cb ','#e78ac3 ','#a6d854 ','#ffd92f '] - it can also stay as it is, though the blue might be close to the one in the proposed HDI scheme


Adapted colors for human development index only

![image](https://user-images.githubusercontent.com/5851088/46875827-0a8ade00-ce3d-11e8-9329-4f8b7d181c90.png)


With the proposed new continent color scheme

![image](https://user-images.githubusercontent.com/5851088/46875887-30b07e00-ce3d-11e8-8b23-5eb2fced5015.png)
