### PR TITLE
Prune visualization options

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@types/materialize-css": "^1.0.3",
     "@types/papaparse": "^4.5.0",
-    "lineupjs": "^4.0.0-alpha.3",
+    "lineupjs": "git://github.com/Caleydo/lineupjs.git#develop",
     "materialize-css": "^0.100.2",
     "papaparse": "^4.5.0",
     "font-awesome": "^4.7.0",

--- a/src/data/aids/index.ts
+++ b/src/data/aids/index.ts
@@ -21,53 +21,52 @@ function stratifications(): IStratification[] {
 
 /**
  * Check which renderer should be available and which one should be disabled.
- * The function is implemented as black list. Add renderer that should be hidden for certain columns and renderer.
+ * The function is implemented as black list. Add the renderer type that should be hidden for certain columns.
  */
-function canRender(renderer: ICellRendererFactory, col: Column, mode: ERenderMode): boolean {
-  // Note: for some renderer the properties `groupTitle` or `summaryTitle` does not exist, in these cases the fallback property `title` is used.
+function canRender(type: string, _renderer: ICellRendererFactory, col: Column, mode: ERenderMode): boolean {
   if(col instanceof CategoricalColumn) {
     switch(mode) {
       case ERenderMode.CELL:
-        return !(renderer.title === 'Table' || renderer.title === 'Heatmap');
+        return !(type === 'table' || type === 'catheatmap');
 
       case ERenderMode.GROUP:
-        return !(renderer.title === 'Table' || renderer.title === 'Heatmap' || renderer.groupTitle === 'None');
+        return !(type === 'table' || type === 'catheatmap' || type === 'default');
 
       case ERenderMode.SUMMARY:
-        return !(renderer.title === 'Table');
+        return !(type === 'table');
     }
 
   } else if(col instanceof NumberColumn) {
     switch(mode) {
       case ERenderMode.GROUP:
-        return !(renderer.groupTitle === 'None');
+        return !(type === 'default');
 
       case ERenderMode.SUMMARY:
-        return !(renderer.summaryTitle === 'None');
+        return !(type === 'default');
     }
 
   } else if(col instanceof StringColumn) {
     switch(mode) {
       case ERenderMode.CELL:
-        return !(renderer.title === 'Default' || renderer.title === 'Image' || renderer.title === 'Link');
+        return !(type === 'default' || type === 'image' || type === 'link');
 
       case ERenderMode.GROUP:
-        return !(renderer.groupTitle === 'None' || renderer.groupTitle === 'Link');
+        return !(type === 'default' || type === 'link');
 
       case ERenderMode.SUMMARY:
-        return !(renderer.summaryTitle === 'Default');
+        return !(type === 'default');
     }
 
   } else if(col instanceof MatrixColumn) {
     switch(mode) {
       case ERenderMode.CELL:
-        return !(renderer.title === 'Bar Table' || renderer.title === 'Bar Chart' || renderer.title === 'Histogram' || renderer.title === 'Table');
+        return !(type === 'mapbars' || type === 'verticalbar' || type === 'histogram' || type === 'table');
 
       case ERenderMode.GROUP:
-        return !(renderer.groupTitle === 'None' || renderer.title === 'Table');
+        return !(type === 'default' || type === 'table');
 
       case ERenderMode.SUMMARY:
-        return !(renderer.title === 'Bar Table' || renderer.title === 'Heatmap' || renderer.title === 'Table');
+        return !(type === 'mapbars' || type === 'heatmap' || type === 'table');
     }
   }
 

--- a/src/data/aids/index.ts
+++ b/src/data/aids/index.ts
@@ -22,6 +22,10 @@ function stratifications(): IStratification[] {
 /**
  * Check which renderer should be available and which one should be disabled.
  * The function is implemented as black list. Add the renderer type that should be hidden for certain columns.
+ * @param type renderer type (see `renderers` in `lineupjs/src/renderer/index.ts`)
+ * @param _renderer the renderer class itself
+ * @param col the column
+ * @param mode the renderer mode
  */
 function canRender(type: string, _renderer: ICellRendererFactory, col: Column, mode: ERenderMode): boolean {
   if(col instanceof CategoricalColumn) {


### PR DESCRIPTION
closes #33

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 


## Summary


### Categorical

* Item vis: removed *Table*, *Heatmap*
* Group vis: removed *None*, *Table*, *Heatmap*
* Summary vis: removed *Table*

![image](https://user-images.githubusercontent.com/5851088/46944525-8cb01800-d072-11e8-8076-81569bc226e3.png)


### Numerical

* Item vis: --
* Group vis: removed *None*
* Summary vis: removed *None*

![image](https://user-images.githubusercontent.com/5851088/46944540-989bda00-d072-11e8-86a4-e18bbf880ad5.png)


### String

* Item vis: removed *Default*, *Image*, *Link*
* Group vis: removed *None* and *Link*, rename *Default* to *Samples*
* Summary vis: removed *Default*

--> No visualization menu available, because there is only one visualization per group left.

### Matrix

* Item vis: removed *Bar chart*, *Bar table*, *Histogram*, *Table*
* Group vis: removed *None* and *Table*
* Summary vis: removed *Bar table*, *Heatmap*, *Table*

![image](https://user-images.githubusercontent.com/5851088/46944594-bf5a1080-d072-11e8-9443-ed313819de2a.png)




